### PR TITLE
add extra newline before both HTML and plain text email contents

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -110,6 +110,7 @@ defmodule Bamboo.SMTPAdapter do
     |> add_multipart_delimiter(multi_part_delimiter)
     |> add_smtp_header_line("Content-Type", "text/html;charset=UTF-8")
     |> add_smtp_header_line("Content-ID", "html-body")
+    |> add_smtp_line("")
     |> add_smtp_line(html_body)
   end
 
@@ -154,6 +155,7 @@ defmodule Bamboo.SMTPAdapter do
     |> add_multipart_delimiter(multi_part_delimiter)
     |> add_smtp_header_line("Content-Type", "text/plain;charset=UTF-8")
     |> add_smtp_header_line("Content-ID", "text-body")
+    |> add_smtp_line("")
     |> add_smtp_line(text_body)
   end
 


### PR DESCRIPTION
This newline is needed so that some email clients recognize multipart email parts properly. Currently Thunderbird, Hotmail and others may not recognize HTML version when both HTML and text versions were provided, displaying either wrong version or blank email.
