### PR TITLE
Allow username and password configs to be loaded from ENV

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -12,8 +12,8 @@ defmodule Bamboo.SMTPAdapter do
         adapter: Bamboo.SMTPAdapter,
         server: "smtp.domain",
         port: 1025,
-        username: "your.name@your.domain",
-        password: "pa55word",
+        username: "your.name@your.domain", # or {:system, "SMTP_USER"}
+        password: "pa55word", # or {:system, "SMTP_PASS"}
         tls: :if_available, # can be `:always` or `:never`
         ssl: :false, # can be `:true`
         retries: 1
@@ -287,8 +287,14 @@ defmodule Bamboo.SMTPAdapter do
   defp to_gen_smtp_server_config({:server, value}, config) do
     [{:relay, value} | config]
   end
+  defp to_gen_smtp_server_config({:username, {:system, var}}, config) do
+    [{:username, System.get_env(var)} | config]
+  end
   defp to_gen_smtp_server_config({:username, value}, config) do
     [{:username, value} | config]
+  end
+  defp to_gen_smtp_server_config({:password, {:system, var}}, config) do
+    [{:password, System.get_env(var)} | config]
   end
   defp to_gen_smtp_server_config({:password, value}, config) do
     [{:password, value} | config]

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -161,6 +161,21 @@ defmodule Bamboo.SMTPAdapterTest do
     assert retries == 42
   end
 
+  test "sets username and password from System when specified" do
+    System.put_env("SMTP_USER", "joeblow")
+    System.put_env("SMTP_PASS", "fromkokomo")
+
+    bamboo_email = new_email
+    bamboo_config = configuration(%{username: {:system, "SMTP_USER"}, password: {:system, "SMTP_PASS"}})
+
+    :ok = SMTPAdapter.deliver(bamboo_email, bamboo_config)
+
+    [{{_from, _to, _raw_email}, gen_smtp_config}] = FakeGenSMTP.fetch_sent_emails
+
+    assert  gen_smtp_config[:username] == "joeblow"
+    assert gen_smtp_config[:password] == "fromkokomo"
+  end
+
   test "emails raise an exception when configuration is wrong" do
     bamboo_email = new_email
     bamboo_config = configuration(%{server: "wrong.smtp.domain"})
@@ -302,7 +317,6 @@ defmodule Bamboo.SMTPAdapterTest do
 
     assert_configuration bamboo_config, gen_smtp_config
   end
-
 
   test "check rfc822 encoding for subject" do
     bamboo_email = @email_in_utf8


### PR DESCRIPTION
It is commonplace to keep credentials (such as SMTP username and password) out of source control by loading them from environment variables.

Unfortunately, you cannot simply do this:

``` elixir
config :my_app, MyApp.Mailer,
  username: System.get_env("SMTP_USER"),
  password: System.get_env("SMTP_PASS")
```

Because those calls are made at compile-time instead of run-time. A common way to work around this (which I think should be built in to Mix somehow, but maybe that's just me) is to let those configuration settings be passed as a tuple of `{:system, "VAR_NAME"}` and then load them from the system at run-time.

Two modules that do this are [Phoenix.Endpoint](https://github.com/phoenixframework/phoenix/blob/master/lib/phoenix/endpoint.ex#L127) and [Ecto](https://github.com/elixir-ecto/ecto/blob/master/lib/ecto/repo/supervisor.ex#L58).

This change introduces identical behavior to bamboo_smtp. The resulting config would be:

``` elixir
config :my_app, MyApp.Mailer,
  username: {:system, "SMTP_USER"},
  password: {:system, "SMTP_PASS"}
```

I tried to write a test to ensure this works as expected, but since `to_gen_smtp_server_config` is a private function and `handle_config` does not call it (curious why not?), I couldn't think of a straight forward way of accomplishing that.

If you provide some guidance on that front, I'm happy to add tests before this gets merged.

🍻 
