### PR TITLE
Remove Content-ID SMTP header from email parts

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -109,7 +109,6 @@ defmodule Bamboo.SMTPAdapter do
     body
     |> add_multipart_delimiter(multi_part_delimiter)
     |> add_smtp_header_line("Content-Type", "text/html;charset=UTF-8")
-    |> add_smtp_header_line("Content-ID", "html-body")
     |> add_smtp_line("")
     |> add_smtp_line(html_body)
   end
@@ -158,7 +157,6 @@ defmodule Bamboo.SMTPAdapter do
     body
     |> add_multipart_delimiter(multi_part_delimiter)
     |> add_smtp_header_line("Content-Type", "text/plain;charset=UTF-8")
-    |> add_smtp_header_line("Content-ID", "text-body")
     |> add_smtp_line("")
     |> add_smtp_line(text_body)
   end

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -209,12 +209,10 @@ defmodule Bamboo.SMTPAdapterTest do
     assert String.contains?(raw_email, "MIME-Version: 1.0\r\n")
     assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
                                         "Content-Type: text/html;charset=UTF-8\r\n" <>
-                                        "Content-ID: html-body\r\n" <>
                                         "\r\n" <>
                                         "#{bamboo_email.html_body}\r\n")
     refute String.contains?(raw_email, "--#{multipart_header}\r\n" <>
                                         "Content-Type: text/plain;charset=UTF-8\r\n" <>
-                                        "Content-ID: text-body\r\n" <>
                                         "\r\n")
 
     assert_configuration bamboo_config, gen_smtp_config
@@ -250,11 +248,9 @@ defmodule Bamboo.SMTPAdapterTest do
     assert String.contains?(raw_email, "MIME-Version: 1.0\r\n")
     refute String.contains?(raw_email, "--#{multipart_header}\r\n" <>
                                         "Content-Type: text/html;charset=UTF-8\r\n" <>
-                                        "Content-ID: html-body\r\n" <>
                                         "\r\n")
     assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
                                         "Content-Type: text/plain;charset=UTF-8\r\n" <>
-                                        "Content-ID: text-body\r\n" <>
                                         "\r\n" <>
                                         "#{bamboo_email.text_body}\r\n")
 
@@ -291,12 +287,10 @@ defmodule Bamboo.SMTPAdapterTest do
     assert String.contains?(raw_email, "MIME-Version: 1.0\r\n")
     assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
                                         "Content-Type: text/html;charset=UTF-8\r\n" <>
-                                        "Content-ID: html-body\r\n" <>
                                         "\r\n" <>
                                         "#{bamboo_email.html_body}\r\n")
     assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
                                         "Content-Type: text/plain;charset=UTF-8\r\n" <>
-                                        "Content-ID: text-body\r\n" <>
                                         "\r\n" <>
                                         "#{bamboo_email.text_body}\r\n")
 


### PR DESCRIPTION
This header causes some email clients to treat parts as attachments. It also doesn't appear to be necessary for email delivery or rendering.

Before:

![2016-07-25 at 8 02 am](https://cloud.githubusercontent.com/assets/8212/17102341/c22c6a74-523e-11e6-93e7-7af25ef95632.png)

After:

![2016-07-25 at 8 07 am](https://cloud.githubusercontent.com/assets/8212/17102358/d51fd92c-523e-11e6-894a-091aa21635a8.png)
