### PR TITLE
Don't need to enforce username/password

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -28,7 +28,7 @@ defmodule Bamboo.SMTPAdapter do
 
   require Logger
 
-  @required_configuration [:server, :port, :username, :password]
+  @required_configuration [:server, :port]
   @default_configuration %{tls: :if_available, ssl: :false, retries: 1, transport: :gen_smtp_client}
 
   defmodule SMTPError do

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -113,18 +113,6 @@ defmodule Bamboo.SMTPAdapterTest do
     end
   end
 
-  test "raises if the username is nil" do
-    assert_raise ArgumentError, ~r/Key username is required/, fn ->
-      SMTPAdapter.handle_config(configuration(%{username: nil}))
-    end
-  end
-
-  test "raises if the password is nil" do
-    assert_raise ArgumentError, ~r/Key password is required/, fn ->
-      SMTPAdapter.handle_config(configuration(%{password: nil}))
-    end
-  end
-
   test "sets default tls key if not present" do
     %{tls: tls} = SMTPAdapter.handle_config(configuration)
 


### PR DESCRIPTION
The underlying `gen_smtp_server` library works just fine without a supplied auth. This change is needed to make it possible to send to SMTP relays that don't use auth.