### PR TITLE
Fix for emails going to spam with office365 smtp

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -178,7 +178,10 @@ defmodule Bamboo.SMTPAdapter do
     Map.put_new(config, key, default_value)
   end
 
-  defp generate_multi_part_delimiter, do: "----=_Part_123456789_987654321.192837465"
+  defp generate_multi_part_delimiter do
+    << random1 :: size(32), random2 :: size(32), random3 :: size(32) >> = :crypto.strong_rand_bytes(12)
+    "----=_Part_#{random1}_#{random2}.#{random3}"
+  end
 
   defp body(%Bamboo.Email{} = email) do
     multi_part_delimiter = generate_multi_part_delimiter()


### PR DESCRIPTION
For some strange reason a static part delimiter is sending our emails to spam. We are using the office365 smtp servers. Sending email with gen_smtp as plain text was sending it without any issues. A diff of the full email text from gmail showed that the only major difference was the part delimiter.