### PR TITLE
Fixed parentheses deprecations for elixir 1.4

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -181,7 +181,7 @@ defmodule Bamboo.SMTPAdapter do
   defp generate_multi_part_delimiter, do: "----=_Part_123456789_987654321.192837465"
 
   defp body(%Bamboo.Email{} = email) do
-    multi_part_delimiter = generate_multi_part_delimiter
+    multi_part_delimiter = generate_multi_part_delimiter()
 
     ""
     |> add_subject(email)

--- a/mix.exs
+++ b/mix.exs
@@ -14,8 +14,8 @@ defmodule BambooSmtp.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      test_coverage: [tool: ExCoveralls],
-     package: package,
-     deps: deps,
+     package: package(),
+     deps: deps(),
      docs: [main: "README", extras: ["README.md"]]]
   end
 


### PR DESCRIPTION
Elixir 1.4 just released lately :tada:

The parentheses are now recommended for method calls without arguments.

This PR fixes the parts where we had deprecations like so... :

```
warning: variable "generate_multi_part_delimiter" does not exist and is being expanded to "generate_multi_part_delimiter()", please use parentheses to remove the ambiguity or change the variable name
  lib/bamboo/adapters/smtp_adapter.ex:184
```

Thanks!