### PR TITLE
Add the raw error tuple when we raise an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The package can be installed as:
 
 4. Follow Bamboo [Getting Started Guide](https://github.com/thoughtbot/bamboo#getting-started)
 
+## Usage
+
+You can find more information about advanced features in the [Wiki](https://github.com/fewlinesco/bamboo_smtp/wiki).
+
 ## Contributing
 
 Before opening a pull request you can open an issue if you have any question or need some guidance.

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -34,9 +34,9 @@ defmodule Bamboo.SMTPAdapter do
   defmodule SMTPError do
     @moduledoc false
 
-    defexception [:message]
+    defexception [:message, :raw]
 
-    def exception({reason, detail}) do
+    def exception(raw = {reason, detail}) do
       message = """
       There was a problem sending the email through SMTP.
 
@@ -47,7 +47,7 @@ defmodule Bamboo.SMTPAdapter do
       #{inspect detail}
       """
 
-      %SMTPError{message: message}
+      %SMTPError{message: message, raw: raw}
     end
   end
 

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -248,6 +248,13 @@ defmodule Bamboo.SMTPAdapterTest do
     assert_raise SMTPAdapter.SMTPError, ~r/network_failure/, fn ->
       SMTPAdapter.deliver(bamboo_email, bamboo_config)
     end
+
+    try do
+      SMTPAdapter.deliver(bamboo_email, bamboo_config)
+    rescue
+      error ->
+        assert {:retries_exceeded, _detail} = error.raw
+    end
   end
 
   test "emails raise an exception when email can't be sent" do
@@ -256,6 +263,13 @@ defmodule Bamboo.SMTPAdapterTest do
 
     assert_raise SMTPAdapter.SMTPError, ~r/554 Message rejected/, fn ->
       SMTPAdapter.deliver(bamboo_email, bamboo_config)
+    end
+
+    try do
+      SMTPAdapter.deliver(bamboo_email, bamboo_config)
+    rescue
+      error ->
+        assert {:no_more_hosts, _detail} = error.raw
     end
   end
 


### PR DESCRIPTION
How to use it?

```elixir
def send_an_email(email) do
  try do
    MyApp.Mailer.deliver_now(email)
  rescue
    error in Bamboo.SMTPAdapter.SMTPError ->
      case error.raw do
        {:retries_exceeded, _} ->
          IO.inspect("I can do some stuff when this error match")
        _ ->
          IO.inspect "I don't care about these ones"
      end
      # Here, I can re-raise the error
      raise error
    end
  end
end
```

Resolve #50