### PR TITLE
Add a CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+We welcome Pull Requests from anyone 👐
+
+By participating in this project, you agree to abide by its [Code of Conduct](CODE_OF_CONDUCT.md).
+
+Before submitting a Pull Request, please ensure the following:
+
+1. Your code is covered by tests
+2. Make sure all tests are passing
+3. Only have one commit with a relevant message (you can rebase and squash all your commits into a single one)
+4. Check that you're up to date by rebasing your branch with our `develop` branch
+
+## Setup
+
+```
+$ git clone https://github.com/fewlinesco/bamboo_smtp.git
+$ cd bamboo_smtp
+$ mix deps.get
+$ mix test
+```

--- a/README.md
+++ b/README.md
@@ -56,18 +56,7 @@ By participating in this project, you agree to abide by its [CODE OF CONDUCT](CO
 
 ## Contributing
 
-Before opening a pull request you can open an issue if you have any question or need some guidance.
-
-Here's how to setup the project:
-
-```
-$ git clone https://github.com/fewlinesco/bamboo_smtp.git
-$ cd bamboo_smtp
-$ mix deps.get
-$ mix test
-```
-
-Once you've made your additions and `mix test` passes, go ahead and open a Pull Request.
+You can see the specific [CONTRIBUTING](CONTRIBUTING.md) guide.
 
 ## License
 


### PR DESCRIPTION
To be in line with the new Community Insights from Github, we need a separate CONTRIBUTING guide.