### PR TITLE
Make the hostname (FQDN) configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The package can be installed as:
   config :my_app, MyApp.Mailer,
     adapter: Bamboo.SMTPAdapter,
     server: "smtp.domain",
+    hostname: "your.domain",
     port: 1025,
     username: "your.name@your.domain", # or {:system, "SMTP_USERNAME"}
     password: "pa55word", # or {:system, "SMTP_PASSWORD"}
@@ -44,6 +45,8 @@ The package can be installed as:
 
 *Sensitive credentials should not be committed to source control and are best kept in environment variables.
 Using `{:system, "ENV_NAME"}` configuration is read from the named environment variable at runtime.*
+
+The *hostname* option sets the FQDN to the header of your emails, its optional, but if you don't set it, the underlying `gen_smtp` module will use the hostname of your machine, like `localhost`.
 
 4. Follow Bamboo [Getting Started Guide](https://github.com/thoughtbot/bamboo#getting-started)
 

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -14,6 +14,7 @@ defmodule Bamboo.SMTPAdapter do
       config :my_app, MyApp.Mailer,
         adapter: Bamboo.SMTPAdapter,
         server: "smtp.domain",
+        hostname: "www.mydomain.com",
         port: 1025,
         username: "your.name@your.domain", # or {:system, "SMTP_USERNAME"}
         password: "pa55word", # or {:system, "SMTP_PASSWORD"}
@@ -342,6 +343,9 @@ defmodule Bamboo.SMTPAdapter do
   end
   defp to_gen_smtp_server_config({:retries, value}, config) when is_integer(value) do
     [{:retries, value} | config]
+  end
+  defp to_gen_smtp_server_config({:hostname, value}, config) when is_binary(value) do
+    [{:hostname, value} | config]
   end
   defp to_gen_smtp_server_config({conf, {:system, var}}, config) do
     to_gen_smtp_server_config({conf, System.get_env(var)}, config)

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -62,6 +62,7 @@ defmodule Bamboo.SMTPAdapterTest do
     adapter: SMTPAdapter,
     server: "smtp.domain",
     port: 1025,
+    hostname: "your.domain",
     username: "your.name@your.domain",
     password: "pa55word",
     transport: FakeGenSMTP
@@ -449,6 +450,7 @@ defmodule Bamboo.SMTPAdapterTest do
   defp assert_configuration(bamboo_config, gen_smtp_config) do
     assert bamboo_config[:server] == gen_smtp_config[:relay]
     assert bamboo_config[:port] == gen_smtp_config[:port]
+    assert bamboo_config[:hostname] == gen_smtp_config[:hostname]
     assert bamboo_config[:username] == gen_smtp_config[:username]
     assert bamboo_config[:password] == gen_smtp_config[:password]
     assert bamboo_config[:tls] == gen_smtp_config[:tls]


### PR DESCRIPTION
https://github.com/Vagabond/gen_smtp#option (hostname)

> hostname the hostname to be used by the smtp relay, Defaults to: smtp_util:guess_FQDN(). The hostname on your computer might not be correct, so set this to a valid value.

A bad FQDN could make your emails be filtered out as spam.