### PR TITLE
Apply rfc822_encode to headers(FROM, BCC, CC, TO)

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -223,7 +223,7 @@ defmodule Bamboo.SMTPAdapter do
   end
 
   defp format_email({nil, email}, _format), do: email
-  defp format_email({name, email}, true), do: "#{name} <#{email}>"
+  defp format_email({name, email}, true), do: "#{rfc822_encode(name)} <#{email}>"
   defp format_email({_name, email}, false), do: email
   defp format_email(emails, format) when is_list(emails) do
     Enum.map(emails, &format_email(&1, format))

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -434,7 +434,7 @@ defmodule Bamboo.SMTPAdapterTest do
 
   defp format_email(emails), do: format_email(emails, true)
 
-  defp format_email({name, email}, true), do: "#{name} <#{email}>"
+  defp format_email({name, email}, true), do: "#{rfc822_encode(name)} <#{email}>"
   defp format_email({_name, email}, false), do: email
   defp format_email(emails, format) when is_list(emails) do
     emails |> Enum.map(&format_email_as_string(&1, format))
@@ -445,6 +445,10 @@ defmodule Bamboo.SMTPAdapterTest do
   end
   defp format_email_as_string(email, format \\ true) do
     format_email(email, format)
+  end
+
+  defp rfc822_encode(content) do
+    "=?UTF-8?B?#{Base.encode64(content)}?="
   end
 
   defp assert_configuration(bamboo_config, gen_smtp_config) do


### PR DESCRIPTION
Hi there. 

There are still corrupting in other header lines particular `FROM` line happened a lot.  Therefore I fixed that.  Thanks.


ref: https://github.com/fewlinesco/bamboo_smtp/pull/15