### PR TITLE
relax Elixir version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 sudo: required
 language: elixir
 elixir:
-  - 1.4.0
   - 1.4.5
+  - 1.5.3
+  - 1.6.0
+  - 1.6.1
 otp_release:
   - 18.3
   - 19.3
@@ -11,6 +13,10 @@ matrix:
   exclude:
     - elixir: 1.4.0
       otp_release: 20.0
+    - elixir: 1.6.0
+      otp_release: 18.3
+    - elixir: 1.6.1
+      otp_release: 18.3
 cache:
   directories:
     - _build

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule BambooSmtp.Mixfile do
   def project do
     [app: :bamboo_smtp,
      version: "1.5.0-rc.2",
-     elixir: "~> 1.4.0",
+     elixir: "~> 1.4",
      source_url: @project_url,
      homepage_url: @project_url,
      name: "Bamboo SMTP Adapter",
@@ -26,7 +26,7 @@ defmodule BambooSmtp.Mixfile do
   defp deps do
     [
       {:bamboo, "~> 1.0.0-rc.2"},
-      {:credo, "~> 0.8.2", only: [:dev, :test]},
+      {:credo, "~> 0.8.10", only: [:dev, :test]},
       {:earmark, ">= 1.0.3", only: :dev},
       {:ex_doc, "~> 0.16.2", only: :dev},
       {:excoveralls, "~> 0.7.1", only: :test},

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{"bamboo": {:hex, :bamboo, "1.0.0-rc.2", "633ff63faf2a6ad17871a7dca2c75390761c33c7f811d0d09a1827aaa21ce164", [:mix], [{:hackney, "~> 1.7", [hex: :hackney, repo: "hexpm", optional: false]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}, {:poison, ">= 1.5.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
-  "credo": {:hex, :credo, "0.8.2", "aa410c8f27c5fab00cab24f8477782bde9100b73d31debdce46625f097cc0e32", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "credo": {:hex, :credo, "0.8.10", "261862bb7363247762e1063713bb85df2bbd84af8d8610d1272cd9c1943bba63", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
   "dogma": {:hex, :dogma, "0.1.13", "7b6c6ad2b3ee6501eda3bd39e197dd5198be8d520d1c175c7f713803683cf27a", [:mix], [{:poison, ">= 2.0.0", [hex: :poison, optional: false]}]},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.2", "3b3e210ebcd85a7c76b4e73f85c5640c011d2a0b2f06dcdf5acdb2ae904e5084", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
This PR relaxes the required Elixir version so it can run on 1.5 without warnings.

As a reference, Bamboo requires Elixir "~> 1.2"

https://github.com/thoughtbot/bamboo/blob/master/mix.exs#L9