### PR TITLE
Add no_mx_lookups option to gen_smtp config

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The package can be installed as:
     tls: :if_available, # can be `:always` or `:never`
     allowed_tls_versions: [:"tlsv1", :"tlsv1.1", :"tlsv1.2"], # or {":system", ALLOWED_TLS_VERSIONS"} w/ comma seprated values (e.g. "tlsv1.1,tlsv1.2")
     ssl: false, # can be `true`
-    retries: 1
+    retries: 1,
+    no_mx_lookups: false # can be `true`
   ```
 
 *Sensitive credentials should not be committed to source control and are best kept in environment variables.

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -21,8 +21,9 @@ defmodule Bamboo.SMTPAdapter do
         tls: :if_available, # can be `:always` or `:never`
         allowed_tls_versions: [:"tlsv1", :"tlsv1.1", :"tlsv1.2"],
         # or {":system", ALLOWED_TLS_VERSIONS"} w/ comma seprated values (e.g. "tlsv1.1,tlsv1.2")
-        ssl: :false, # can be `:true`
-        retries: 1
+        ssl: false, # can be `true`,
+        retries: 1,
+        no_mx_lookups: false # can be `true`
 
       # Define a Mailer. Maybe in lib/my_app/mailer.ex
       defmodule MyApp.Mailer do
@@ -393,6 +394,15 @@ defmodule Bamboo.SMTPAdapter do
   end
   defp to_gen_smtp_server_config({:hostname, value}, config) when is_binary(value) do
     [{:hostname, value} | config]
+  end
+  defp to_gen_smtp_server_config({:no_mx_lookups, "true"}, config) do
+    [{:no_mx_lookups, true} | config]
+  end
+  defp to_gen_smtp_server_config({:no_mx_lookups, "false"}, config) do
+    [{:no_mx_lookups, false} | config]
+  end
+  defp to_gen_smtp_server_config({:no_mx_lookups, value}, config) when is_boolean(value) do
+    [{:no_mx_lookups, value} | config]
   end
   defp to_gen_smtp_server_config({conf, {:system, var}}, config) do
     to_gen_smtp_server_config({conf, System.get_env(var)}, config)


### PR DESCRIPTION
Hello,

I added `no_mx_lookups` option to `gen_smtp` config.
This option can help when you don't want to connect to the returned mx's of relay.

The `no_mx_lookups` is not mentioned in the `gen_smtp` README,
please, see <https://github.com/Vagabond/gen_smtp/blob/master/src/gen_smtp_client.erl#L136> for more details.

What do you think? Would it be valid?

Thanks.