### PR TITLE
Add Content-Id to support inline image attachments

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -191,6 +191,7 @@ defmodule Bamboo.SMTPAdapter do
     body
     |> add_smtp_line("Content-Type: #{attachment.content_type}; name=\"#{attachment.filename}\"")
     |> add_smtp_line("Content-Disposition: attachment; filename=\"#{attachment.filename}\"")
+    |> add_smtp_line("Content-Id: <#{attachment.filename}>")
     |> add_smtp_line("Content-Transfer-Encoding: base64")
     |> add_smtp_line("X-Attachment-Id: #{random}")
   end


### PR DESCRIPTION
In order to show images inline in an email, attachments need a content-id (according to [RFC2392](https://tools.ietf.org/html/rfc2392)). Since Bamboo's attachment struct doesn't seem extensible, it's easiest to just add a Content-Id to every attachment sent. With this, users can refer to images by filename:

`<img src="cid:<%= filename %>" />`