### PR TITLE
Require username and password in configuration

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -36,7 +36,7 @@ defmodule Bamboo.SMTPAdapter do
 
   require Logger
 
-  @required_configuration [:server, :port]
+  @required_configuration [:server, :port, :username, :password]
   @default_configuration %{
     tls: :if_available,
     ssl: :false,

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -115,6 +115,18 @@ defmodule Bamboo.SMTPAdapterTest do
     end
   end
 
+  test "raises if username is nil" do
+    assert_raise ArgumentError, ~r/Key username is required/, fn ->
+      SMTPAdapter.handle_config(configuration(%{username: nil}))
+    end
+  end
+
+  test "raises if password is nil" do
+    assert_raise ArgumentError, ~r/Key password is required/, fn ->
+      SMTPAdapter.handle_config(configuration(%{password: nil}))
+    end
+  end
+
   test "sets default tls key if not present" do
     %{tls: tls} = SMTPAdapter.handle_config(configuration())
 


### PR DESCRIPTION
The gen_smtp library requires these to be present

See https://github.com/Vagabond/gen_smtp/blob/2d347f81dc354c3ee78ccbc22efabc5c08260552/src/gen_smtp_client.erl#L673