### PR TITLE
Don't send blank cc/bcc to SMTP MTA

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -100,7 +100,7 @@ defmodule Bamboo.SMTPAdapter do
     {:ok, response}
   end
 
-  defp add_bcc(body, %Bamboo.Email{bcc: recipients}) when length(recipients) == 0 do
+  defp add_bcc(body, %Bamboo.Email{bcc: []}) do
     body
   end
 
@@ -108,7 +108,7 @@ defmodule Bamboo.SMTPAdapter do
     add_smtp_header_line(body, :bcc, format_email_as_string(recipients, :bcc))
   end
 
-  defp add_cc(body, %Bamboo.Email{cc: recipients}) when length(recipients) == 0 do
+  defp add_cc(body, %Bamboo.Email{cc: []}) do
     body
   end
 

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -100,8 +100,16 @@ defmodule Bamboo.SMTPAdapter do
     {:ok, response}
   end
 
+  defp add_bcc(body, %Bamboo.Email{bcc: recipients}) when length(recipients) == 0 do
+    body
+  end
+
   defp add_bcc(body, %Bamboo.Email{bcc: recipients}) do
     add_smtp_header_line(body, :bcc, format_email_as_string(recipients, :bcc))
+  end
+
+  defp add_cc(body, %Bamboo.Email{cc: recipients}) when length(recipients) == 0 do
+    body
   end
 
   defp add_cc(body, %Bamboo.Email{cc: recipients}) do

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -534,6 +534,84 @@ defmodule Bamboo.SMTPAdapterTest do
     assert_configuration bamboo_config, gen_smtp_config
   end
 
+  test "email looks fine when no bcc: is set" do
+    bamboo_email = new_email(bcc: [])
+    bamboo_config = configuration()
+
+    {:ok, "200 Ok 1234567890"} = SMTPAdapter.deliver(bamboo_email, bamboo_config)
+
+    assert 1 = length(FakeGenSMTP.fetch_sent_emails)
+
+    [{{from, to, raw_email}, gen_smtp_config}] = FakeGenSMTP.fetch_sent_emails
+
+    [multipart_header] =
+      Regex.run(
+        ~r{Content-Type: multipart/alternative; boundary="([^"]+)"\r\n},
+        raw_email,
+        capture: :all_but_first)
+
+    assert format_email_as_string(bamboo_email.from, false) == from
+    assert format_email(bamboo_email.to ++ bamboo_email.cc ++ bamboo_email.bcc, false) == to
+
+    rfc822_subject = "Subject: =?UTF-8?B?SGVsbG8gZnJvbSBCYW1ib28=?=\r\n"
+    assert String.contains?(raw_email, rfc822_subject)
+
+    assert String.contains?(raw_email, "From: #{format_email_as_string(bamboo_email.from)}\r\n")
+    assert String.contains?(raw_email, "To: #{format_email_as_string(bamboo_email.to)}\r\n")
+    assert String.contains?(raw_email, "Cc: #{format_email_as_string(bamboo_email.cc)}\r\n")
+    refute String.contains?(raw_email, "Bcc: #{format_email_as_string(bamboo_email.bcc)}\r\n")
+    assert String.contains?(raw_email, "Reply-To: reply@doe.com\r\n")
+    assert String.contains?(raw_email, "MIME-Version: 1.0\r\n")
+    assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
+                                        "Content-Type: text/html;charset=UTF-8\r\n" <>
+                                        "\r\n" <>
+                                        "#{bamboo_email.html_body}\r\n")
+    assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
+                                        "Content-Type: text/plain;charset=UTF-8\r\n" <>
+                                        "\r\n")
+
+    assert_configuration bamboo_config, gen_smtp_config
+  end
+
+  test "email looks fine when no cc: is set" do
+    bamboo_email = new_email(cc: [])
+    bamboo_config = configuration()
+
+    {:ok, "200 Ok 1234567890"} = SMTPAdapter.deliver(bamboo_email, bamboo_config)
+
+    assert 1 = length(FakeGenSMTP.fetch_sent_emails)
+
+    [{{from, to, raw_email}, gen_smtp_config}] = FakeGenSMTP.fetch_sent_emails
+
+    [multipart_header] =
+      Regex.run(
+        ~r{Content-Type: multipart/alternative; boundary="([^"]+)"\r\n},
+        raw_email,
+        capture: :all_but_first)
+
+    assert format_email_as_string(bamboo_email.from, false) == from
+    assert format_email(bamboo_email.to ++ bamboo_email.cc ++ bamboo_email.bcc, false) == to
+
+    rfc822_subject = "Subject: =?UTF-8?B?SGVsbG8gZnJvbSBCYW1ib28=?=\r\n"
+    assert String.contains?(raw_email, rfc822_subject)
+
+    assert String.contains?(raw_email, "From: #{format_email_as_string(bamboo_email.from)}\r\n")
+    assert String.contains?(raw_email, "To: #{format_email_as_string(bamboo_email.to)}\r\n")
+    refute String.contains?(raw_email, "Cc: #{format_email_as_string(bamboo_email.cc)}\r\n")
+    assert String.contains?(raw_email, "Bcc: #{format_email_as_string(bamboo_email.bcc)}\r\n")
+    assert String.contains?(raw_email, "Reply-To: reply@doe.com\r\n")
+    assert String.contains?(raw_email, "MIME-Version: 1.0\r\n")
+    assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
+                                        "Content-Type: text/html;charset=UTF-8\r\n" <>
+                                        "\r\n" <>
+                                        "#{bamboo_email.html_body}\r\n")
+    assert String.contains?(raw_email, "--#{multipart_header}\r\n" <>
+                                        "Content-Type: text/plain;charset=UTF-8\r\n" <>
+                                        "\r\n")
+
+    assert_configuration bamboo_config, gen_smtp_config
+  end
+
   test "check rfc822 encoding for subject" do
     bamboo_email = @email_in_utf8
     |> Email.new_email


### PR DESCRIPTION
When cc or bcc is an empty list, a cc or bcc header is sent to the SMTP MTA with a blank value (e.g. `Cc: ` or `Bcc:`). To avoid blank values in the sent email, these are filtered out.