### PR TITLE
update changelog and mix version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 2.1.0 - 2019-10-14
+
+- SMTPAdapter now does not append `Bcc` and `Cc` headers to the body if there is not any provided.
+
 ## 2.0.0 - 2019-08-27
 
 - SMTPAdapter now returns the SMTP server response ([#122])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## 2.1.0 - 2019-10-14
 
-- SMTPAdapter now does not append `Bcc` and `Cc` headers to the body if there is not any provided.
+- SMTPAdapter now does not append `Bcc` and `Cc` headers to the body if there is not any provided ([#130]).
+- Bump `gen_smtp` version to `~> 0.15.0` ([#129]).
+- Bump `ex_doc` version for system version at least equal to `1.7` ([#127]).
+
+[#130]: https://github.com/fewlinesco/bamboo_smtp/pull/130
+[#129]: https://github.com/fewlinesco/bamboo_smtp/pull/129
+[#127]: https://github.com/fewlinesco/bamboo_smtp/pull/127
 
 ## 2.0.0 - 2019-08-27
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed as:
 
   ```elixir
   def deps do
-    [{:bamboo_smtp, "~> 2.0.0"}]
+    [{:bamboo_smtp, "~> 2.1.0"}]
   end
   ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule BambooSmtp.Mixfile do
   def project do
     [
       app: :bamboo_smtp,
-      version: "2.0.0",
+      version: "2.1.0",
       elixir: "~> 1.4",
       source_url: @project_url,
       homepage_url: @project_url,


### PR DESCRIPTION
## Details 

This pull request prepares the publication of a new minor version of `bamboo_smtp` including an improvement on body string generation. 
`Bcc` and `Cc` are now ignored if blank whereas they were appended with a blank string value in the previous implementation.