### PR TITLE
Use atoms for config values in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The package can be installed as:
     ssl: false, # can be `true`
     retries: 1,
     no_mx_lookups: false, # can be `true`
-    auth: :if_available # can be `always`. If your smtp relay requires authentication set it to `always`.
+    auth: :if_available # can be `:always`. If your smtp relay requires authentication set it to `:always`.
   ```
 
 *Sensitive credentials should not be committed to source control and are best kept in environment variables.

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -24,7 +24,7 @@ defmodule Bamboo.SMTPAdapter do
         ssl: false, # can be `true`,
         retries: 1,
         no_mx_lookups: false, # can be `true`
-        auth: :if_available # can be `always`. If your smtp relay requires authentication set it to `always`.
+        auth: :if_available # can be `:always`. If your smtp relay requires authentication set it to `:always`.
 
       # Define a Mailer. Maybe in lib/my_app/mailer.ex
       defmodule MyApp.Mailer do


### PR DESCRIPTION
As in the `:tls` block.