### PR TITLE
Bump to v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 3.0.0 - 2020-09-10
+
+- Fix eml attachment ([#137]).
+- Change text/html part to be submitted with base64 encoding to comply to the MIME Format of Internet Message Bodies specification ([#141]).
+- After bumping the dependencies, the project requires elixir 1.7 or higher to run ([#139]).
+
+[#137]: https://github.com/fewlinesco/bamboo_smtp/pull/137
+[#141]: https://github.com/fewlinesco/bamboo_smtp/pull/141
+[#139]: https://github.com/fewlinesco/bamboo_smtp/pull/139
+
 ## 2.1.0 - 2019-10-14
 
 - SMTPAdapter now does not append `Bcc` and `Cc` headers to the body if there is not any provided ([#130]).

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed as:
 
   ```elixir
   def deps do
-    [{:bamboo_smtp, "~> 2.1.0"}]
+    [{:bamboo_smtp, "~> 3.0.0"}]
   end
   ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule BambooSmtp.Mixfile do
   def project do
     [
       app: :bamboo_smtp,
-      version: "2.1.0",
+      version: "3.0.0",
       elixir: "~> 1.7",
       source_url: @project_url,
       homepage_url: @project_url,


### PR DESCRIPTION
This release contains:

- Fix eml attachment ([#137]).
- Change text/html part to be submitted with base64 encoding to comply to the MIME Format of Internet Message Bodies specification ([#141]).
- After bumping the dependencies, the project requires elixir 1.7 or higher to run ([#139]).

[#137]: https://github.com/fewlinesco/bamboo_smtp/pull/137
[#141]: https://github.com/fewlinesco/bamboo_smtp/pull/141
[#139]: https://github.com/fewlinesco/bamboo_smtp/pull/139