### PR TITLE
Create a custom test adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ The *hostname* option sets the FQDN to the header of your emails, its optional, 
 
 4. Follow Bamboo [Getting Started Guide](https://github.com/thoughtbot/bamboo#getting-started)
 
+ Optional step: You can also set `BambooSMTP.TestAdapter` as your test adapter if you expect a response that follow the format of a SMTP server raw response on your tests. 
+
 ## Usage
 
 You can find more information about advanced features in the [Wiki](https://github.com/fewlinesco/bamboo_smtp/wiki).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[Optional step: You can also set `BambooSMTP.TestAdapter` as your test adapter if you expect a response that follow the format of a SMTP server raw response on your tests.![Hex pm](https://img.shields.io/hexpm/v/bamboo_smtp.svg)](https://hex.pm/packages/bamboo_smtp)
+[![Hex pm](https://img.shields.io/hexpm/v/bamboo_smtp.svg)](https://hex.pm/packages/bamboo_smtp)
 [![Build Status](https://travis-ci.org/fewlinesco/bamboo_smtp.svg?branch=master)](https://travis-ci.org/fewlinesco/bamboo_smtp)
 [![Inline docs](http://inch-ci.org/github/fewlinesco/bamboo_smtp.svg)](http://inch-ci.org/github/fewlinesco/bamboo_smtp)
 
@@ -54,13 +54,12 @@ The *hostname* option sets the FQDN to the header of your emails, its optional, 
 
 5. **Optional** Set `BambooSMTP.TestAdapter` as your test adapter:
 
-```elixir
-# In your config/config.exs file
-if Mix.env() == :test do
-  config :my_app, MyApp.Mailer, adapter: MyApp.SMTPTestAdapter
-end
-```
-
+  ```elixir
+ # In your config/config.exs file
+ if Mix.env() == :test do
+   config :my_app, MyApp.Mailer, adapter: MyApp.SMTPTestAdapter
+ end
+ ```
 ## Usage
 
 You can find more information about advanced features in the [Wiki](https://github.com/fewlinesco/bamboo_smtp/wiki).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Hex pm](https://img.shields.io/hexpm/v/bamboo_smtp.svg)](https://hex.pm/packages/bamboo_smtp)
+[Optional step: You can also set `BambooSMTP.TestAdapter` as your test adapter if you expect a response that follow the format of a SMTP server raw response on your tests.![Hex pm](https://img.shields.io/hexpm/v/bamboo_smtp.svg)](https://hex.pm/packages/bamboo_smtp)
 [![Build Status](https://travis-ci.org/fewlinesco/bamboo_smtp.svg?branch=master)](https://travis-ci.org/fewlinesco/bamboo_smtp)
 [![Inline docs](http://inch-ci.org/github/fewlinesco/bamboo_smtp.svg)](http://inch-ci.org/github/fewlinesco/bamboo_smtp)
 
@@ -52,7 +52,14 @@ The *hostname* option sets the FQDN to the header of your emails, its optional, 
 
 4. Follow Bamboo [Getting Started Guide](https://github.com/thoughtbot/bamboo#getting-started)
 
- Optional step: You can also set `BambooSMTP.TestAdapter` as your test adapter if you expect a response that follow the format of a SMTP server raw response on your tests. 
+5. **Optional** Set `BambooSMTP.TestAdapter` as your test adapter:
+
+```elixir
+# In your config/config.exs file
+if Mix.env() == :test do
+  config :my_app, MyApp.Mailer, adapter: MyApp.SMTPTestAdapter
+end
+```
 
 ## Usage
 

--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -24,7 +24,7 @@ defmodule BambooSMTP.TestAdapter do
 
   @doc false
   def deliver(_email, _config) do
-    send(test_procss(), {:ok, "Ok #{Enum.random(100_000_000..999_999_999)}"})
+    send(test_process(), {:ok, "Ok #{Enum.random(100_000_000..999_999_999)}"})
   end
 
   defp test_process do

--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -1,6 +1,8 @@
 defmodule BambooSMTP.TestAdapter do
   @moduledoc """
-  Used for testing email delivery. Reimplementation of `Bamboo.TestAdapter` with a response more 
+  Based on `Bamboo.TestAdapter`, this module can be used for testing email delivery.
+  
+  The `deliver/2` function will provide a response that follow the format of a SMTP server raw response.
   consistent with elixir conventions and closer to a real request
 
   No emails are sent, instead it sends back `{%Bamboo.Email{...}, {:ok,"<raw_smtp_response>"}}` 

--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -1,9 +1,8 @@
 defmodule BambooSMTP.TestAdapter do
   @moduledoc """
   Based on `Bamboo.TestAdapter`, this module can be used for testing email delivery.
-  
+
   The `deliver/2` function will provide a response that follow the format of a SMTP server raw response.
-  consistent with elixir conventions and closer to a real request
 
   No emails are sent, instead it sends back `{%Bamboo.Email{...}, {:ok,"<raw_smtp_response>"}}` 
   for success and raise an exception on error.

--- a/lib/bamboo/adapters/test_adapter.ex
+++ b/lib/bamboo/adapters/test_adapter.ex
@@ -1,0 +1,55 @@
+defmodule BambooSMTP.TestAdapter do
+  @moduledoc """
+  Used for testing email delivery. Reimplementation of `Bamboo.TestAdapter` with a response more 
+  consistent with elixir conventions and closer to a real request
+
+  No emails are sent, instead it sends back `{%Bamboo.Email{...}, {:ok,"<raw_smtp_response>"}}` 
+  for success and raise an exception on error.
+
+  ## Example config
+
+      # Typically done in config/test.exs
+      config :my_app, MyApp.Mailer,
+        adapter: BambooSMTP.TestAdapter
+
+      # Define a Mailer. Typically in lib/my_app/mailer.ex
+      defmodule MyApp.Mailer do
+        use Bamboo.Mailer, otp_app: :my_app
+      end
+  """
+
+  @behaviour Bamboo.Adapter
+
+  @doc false
+  def deliver(_email, _config) do
+    send(test_procss(), {:ok, "Ok #{Enum.random(100_000_000..999_999_999)}"})
+  end
+
+  defp test_process do
+    Application.get_env(:bamboo, :shared_test_process) || self()
+  end
+
+  def handle_config(config) do
+    case config[:deliver_later_strategy] do
+      nil ->
+        Map.put(config, :deliver_later_strategy, Bamboo.ImmediateDeliveryStrategy)
+
+      Bamboo.ImmediateDeliveryStrategy ->
+        config
+
+      _ ->
+        raise ArgumentError, """
+        BambooSMTP.TestAdapter requires that the deliver_later_strategy is
+        Bamboo.ImmediateDeliveryStrategy
+
+        Instead it got: #{inspect(config[:deliver_later_strategy])}
+
+        Please remove the deliver_later_strategy from your config options, or
+        set it to Bamboo.ImmediateDeliveryStrategy.
+        """
+    end
+  end
+
+  @doc false
+  def supports_attachments?, do: true
+end


### PR DESCRIPTION
This pull request adds a custom test adapter that mocks the response from a SMTP provider. The standard test adapter bamboo delivers does not fits to tests that expects a SMTP response.