### PR TITLE
Attach FakeGenSMTP to test supervision tree

### DIFF
--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -12,7 +12,7 @@ defmodule Bamboo.SMTPAdapterTest do
       {:ok, args}
     end
 
-    def start_link do
+    def start_link(_) do
       GenServer.start_link(__MODULE__, [], name: __MODULE__)
     end
 
@@ -115,7 +115,7 @@ defmodule Bamboo.SMTPAdapterTest do
   ]
 
   setup do
-    FakeGenSMTP.start_link()
+    start_supervised!(FakeGenSMTP)
 
     :ok
   end


### PR DESCRIPTION
This pull request updates our tests to make the `FakeGenSMTP` GenServer be attached to the test supervision tree. It may fix the current issue we have that cause random fails in our CI pipeline.