### PR TITLE
Add Content-ID header when needed

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -225,7 +225,19 @@ defmodule Bamboo.SMTPAdapter do
     |> add_smtp_line(text_body)
   end
 
-  defp add_attachment_header(body, %{content_type: content_type} = attachment)
+  defp add_attachment_header(body, attachment) do
+    case attachment.content_id do
+      nil ->
+        add_common_attachment_header(body, attachment)
+
+      cid ->
+        body
+        |> add_common_attachment_header(attachment)
+        |> add_smtp_line("Content-ID: <#{cid}>")
+    end
+  end
+
+  defp add_common_attachment_header(body, %{content_type: content_type} = attachment)
        when content_type == "message/rfc822" do
     <<random::size(32)>> = :crypto.strong_rand_bytes(4)
 
@@ -235,7 +247,7 @@ defmodule Bamboo.SMTPAdapter do
     |> add_smtp_line("X-Attachment-Id: #{random}")
   end
 
-  defp add_attachment_header(body, attachment) do
+  defp add_common_attachment_header(body, attachment) do
     <<random::size(32)>> = :crypto.strong_rand_bytes(4)
 
     body

--- a/test/attachments/attachment_one.txt
+++ b/test/attachments/attachment_one.txt
@@ -1,0 +1,1 @@
+Attachment One.

--- a/test/attachments/attachment_two.txt
+++ b/test/attachments/attachment_two.txt
@@ -1,0 +1,1 @@
+Attachment Two.


### PR DESCRIPTION
This pull request add a header `Content-ID` to email when given `Bamboo.attachment` have a `content_id` set.