### PR TITLE
[CU-9ux5yt] Fix unhandled exception

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -79,7 +79,7 @@ defmodule Bamboo.SMTPAdapter do
         |> config[:transport].send_blocking(gen_smtp_config)
       catch
         e ->
-          handle_response({:error, e})
+          raise SMTPError, {:not_specified, detail}
       end
 
     handle_response(response)

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -108,7 +108,6 @@ defmodule Bamboo.SMTPAdapter do
   end
 
   defp handle_response(response) do
-    Logger.debug("WTF: #{response} ")
     {:ok, response}
   end
 

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -79,7 +79,7 @@ defmodule Bamboo.SMTPAdapter do
         |> config[:transport].send_blocking(gen_smtp_config)
       catch
         e ->
-          raise SMTPError, {:not_specified, detail}
+          raise SMTPError, {:not_specified, e}
       end
 
     handle_response(response)


### PR DESCRIPTION
This pull request solves the issue #148 by catching an exception from `gen_smtp` and re-raising it as a `SMTPError`.