### PR TITLE
Issue #162 subject has encoding while text is not encoded

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -202,17 +202,7 @@ defmodule Bamboo.SMTPAdapter do
   end
 
   defp rfc822_encode(content) do
-    if contains_only_ascii_characters?(content) do
-      "=?UTF-8?B?#{content}?="
-    else
-      "=?UTF-8?B?#{Base.encode64(content)}?="
-    end
-  end
-
-  defp contains_only_ascii_characters?(content) do
-    content
-    |> String.to_charlist()
-    |> List.ascii_printable?()
+    "=?UTF-8?B?#{Base.encode64(content)}?="
   end
 
   def base64_and_split(data) do

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -434,8 +434,7 @@ defmodule Bamboo.SMTPAdapterTest do
     assert format_email_as_string(bamboo_email.from, false) == from
     assert format_email(bamboo_email.to ++ bamboo_email.cc ++ bamboo_email.bcc, false) == to
 
-    rfc822_subject = "Subject: =?UTF-8?B?Hello from Bamboo?=\r\n"
-    assert String.contains?(raw_email, rfc822_subject)
+    assert String.contains?(raw_email, "Subject: #{rfc822_encode("Hello from Bamboo")}")
 
     assert String.contains?(raw_email, "From: #{format_email_as_string(bamboo_email.from)}\r\n")
     assert String.contains?(raw_email, "To: #{format_email_as_string(bamboo_email.to)}\r\n")
@@ -473,8 +472,8 @@ defmodule Bamboo.SMTPAdapterTest do
 
     [{{_from, _to, raw_email}, gen_smtp_config}] = FakeGenSMTP.fetch_sent_emails()
 
-    rfc822_subject = "Subject: \r\n"
-    assert String.contains?(raw_email, rfc822_subject)
+    plain_text = "Subject: \r\n"
+    assert String.contains?(raw_email, plain_text)
 
     assert_configuration(bamboo_config, gen_smtp_config)
   end
@@ -499,9 +498,7 @@ defmodule Bamboo.SMTPAdapterTest do
     assert format_email_as_string(bamboo_email.from, false) == from
     assert format_email(bamboo_email.to ++ bamboo_email.cc ++ bamboo_email.bcc, false) == to
 
-    rfc822_subject = "Subject: =?UTF-8?B?Hello from Bamboo?=\r\n"
-    assert String.contains?(raw_email, rfc822_subject)
-
+    assert String.contains?(raw_email, "Subject: #{rfc822_encode("Hello from Bamboo")}")
     assert String.contains?(raw_email, "From: #{format_email_as_string(bamboo_email.from)}\r\n")
     assert String.contains?(raw_email, "To: #{format_email_as_string(bamboo_email.to)}\r\n")
     assert String.contains?(raw_email, "Cc: #{format_email_as_string(bamboo_email.cc)}\r\n")
@@ -547,9 +544,7 @@ defmodule Bamboo.SMTPAdapterTest do
     assert format_email_as_string(bamboo_email.from, false) == from
     assert format_email(bamboo_email.to ++ bamboo_email.cc ++ bamboo_email.bcc, false) == to
 
-    rfc822_subject = "Subject: =?UTF-8?B?Hello from Bamboo?=\r\n"
-    assert String.contains?(raw_email, rfc822_subject)
-
+    assert String.contains?(raw_email, "Subject: #{rfc822_encode("Hello from Bamboo")}")
     assert String.contains?(raw_email, "From: #{format_email_as_string(bamboo_email.from)}\r\n")
     assert String.contains?(raw_email, "To: #{format_email_as_string(bamboo_email.to)}\r\n")
     assert String.contains?(raw_email, "Cc: #{format_email_as_string(bamboo_email.cc)}\r\n")
@@ -597,9 +592,7 @@ defmodule Bamboo.SMTPAdapterTest do
     assert format_email_as_string(bamboo_email.from, false) == from
     assert format_email(bamboo_email.to ++ bamboo_email.cc ++ bamboo_email.bcc, false) == to
 
-    rfc822_subject = "Subject: =?UTF-8?B?Hello from Bamboo?=\r\n"
-    assert String.contains?(raw_email, rfc822_subject)
-
+    assert String.contains?(raw_email, "Subject: #{rfc822_encode("Hello from Bamboo")}")
     assert String.contains?(raw_email, "From: #{format_email_as_string(bamboo_email.from)}\r\n")
     assert String.contains?(raw_email, "To: #{format_email_as_string(bamboo_email.to)}\r\n")
     assert String.contains?(raw_email, "Cc: #{format_email_as_string(bamboo_email.cc)}\r\n")
@@ -646,9 +639,7 @@ defmodule Bamboo.SMTPAdapterTest do
     assert format_email_as_string(bamboo_email.from, false) == from
     assert format_email(bamboo_email.to ++ bamboo_email.cc ++ bamboo_email.bcc, false) == to
 
-    rfc822_subject = "Subject: =?UTF-8?B?Hello from Bamboo?=\r\n"
-    assert String.contains?(raw_email, rfc822_subject)
-
+    assert String.contains?(raw_email, "Subject: #{rfc822_encode("Hello from Bamboo")}")
     assert String.contains?(raw_email, "From: #{format_email_as_string(bamboo_email.from)}\r\n")
     assert String.contains?(raw_email, "To: #{format_email_as_string(bamboo_email.to)}\r\n")
     refute String.contains?(raw_email, "Cc: #{format_email_as_string(bamboo_email.cc)}\r\n")
@@ -786,17 +777,7 @@ defmodule Bamboo.SMTPAdapterTest do
   end
 
   defp rfc822_encode(content) do
-    if contains_only_ascii_characters?(content) do
-      "=?UTF-8?B?#{content}?="
-    else
-      "=?UTF-8?B?#{Base.encode64(content)}?="
-    end
-  end
-
-  defp contains_only_ascii_characters?(content) do
-    content
-    |> String.to_charlist()
-    |> List.ascii_printable?()
+    "=?UTF-8?B?#{Base.encode64(content)}?="
   end
 
   defp assert_configuration(bamboo_config, gen_smtp_config) do


### PR DESCRIPTION
The `rfc822_encode` method retunrs a text which includes `base64`
information while the code is plain text. This leads to a wrong
presentation of the header in some mail clients (e.g. Thunderbird).

Eather the method should encode everytext or it should return `plain text` as base64 encoding is not needed.

I prefer the plain text solution, as keeps the mail header more readable.

Any ideas, suggestions critics is welcome.