### PR TITLE
Bump to version 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.1.1 - 2021-01-04
+- Bring back Base64 encoding on headers. Fix issue [#162]
+
+[#162]: https://github.com/fewlinesco/bamboo_smtp/pull/162
 ## 3.1.0 - 2020-11-23
 
 - Fix for using custom config with `response: true` by bumping `bamboo` version to `~> 1.6` ([#150])

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BambooSmtp.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/fewlinesco/bamboo_smtp"
-  @version "3.1.0"
+  @version "3.1.1"
 
   def project do
     [
@@ -55,7 +55,10 @@ defmodule BambooSmtp.Mixfile do
     [
       maintainers: ["Kevin Disneur", "Thomas Gautier"],
       licenses: ["MIT"],
-      links: %{"Changelog" => "#{@project_url}/blob/master/CHANGELOG.md", "GitHub" => @project_url}
+      links: %{
+        "Changelog" => "#{@project_url}/blob/master/CHANGELOG.md",
+        "GitHub" => @project_url
+      }
     ]
   end
 


### PR DESCRIPTION
This release brings back Base64 encoding on headers

