### PR TITLE
Add support for gen_smtp_client sockopts

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -517,6 +517,10 @@ defmodule Bamboo.SMTPAdapter do
     [{:auth, value} | config]
   end
 
+  defp to_gen_smtp_server_config({:sockopts, value}, config) do
+    [{:sockopts, value} | config]
+  end
+
   defp to_gen_smtp_server_config({conf, {:system, var}}, config) do
     to_gen_smtp_server_config({conf, System.get_env(var)}, config)
   end


### PR DESCRIPTION
This patch allows the SMTP adaptor to work in ipv6-only environment by using `[:inet6, {:ip, {0,0,0,0,0,0,0,0}}]` as `sockopts`. 'Fixes' #143.