### PR TITLE
Release/v3.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.1.2 - 2021-01-29
+- Enable Bamboo_smtp to work in ipv6-only environment. Fix issue([#143]).
+
+[#143]: https://github.com/fewlinesco/bamboo_smtp/issues/143
 ## 3.1.1 - 2021-01-04
 - Bring back Base64 encoding on headers. Fix issue [#162]
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The package can be installed as:
 
    ```elixir
    def deps do
-     [{:bamboo_smtp, "~> 3.1.0"}]
+     [{:bamboo_smtp, "~> 3.1.2"}]
    end
    ```
 
@@ -50,7 +50,7 @@ The package can be installed as:
    ```
 
    *Sensitive credentials should not be committed to source control and are best kept in environment variables.
-   Using `{:system, "ENV_NAME"}` configuration is read from the named environment variable at runtime.*  
+   Using `{:system, "ENV_NAME"}` configuration is read from the named environment variable at runtime.*
 
    The *hostname* option sets the FQDN to the header of your emails, its optional, but if you don't set it, the underlying `gen_smtp` module will use the hostname of your machine, like `localhost`.
 

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -517,6 +517,10 @@ defmodule Bamboo.SMTPAdapter do
     [{:auth, value} | config]
   end
 
+  defp to_gen_smtp_server_config({:sockopts, value}, config) do
+    [{:sockopts, value} | config]
+  end
+
   defp to_gen_smtp_server_config({conf, {:system, var}}, config) do
     to_gen_smtp_server_config({conf, System.get_env(var)}, config)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BambooSmtp.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/fewlinesco/bamboo_smtp"
-  @version "3.1.1"
+  @version "3.1.2"
 
   def project do
     [


### PR DESCRIPTION
this Release enables `bamboo_smtp` to work in ipv6-only environment.