### PR TITLE
bump to v3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 3.1.3 - 2021-02-11
+
+- Update `gen_smtp` dependency from 1.0.1 to 1.1.0 ([#171])
+    - This project now requires Erlang/OTP+20
+
 ## 3.1.2 - 2021-01-29
 - Enable Bamboo_smtp to work in ipv6-only environment. Fix issue([#143]).
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The package can be installed as:
 
    ```elixir
    def deps do
-     [{:bamboo_smtp, "~> 3.1.2"}]
+     [{:bamboo_smtp, "~> 3.1.3"}]
    end
    ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BambooSmtp.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/fewlinesco/bamboo_smtp"
-  @version "3.1.2"
+  @version "3.1.3"
 
   def project do
     [


### PR DESCRIPTION
This release contains:
- bump `gen_smtp` from 1.0.1 to 1.1.0
