### PR TITLE
release v4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # CHANGELOG
 
+## 4.1.0
+
+- Bump elixir to 1.12.0 and erlang to 24.0 ([#191])
+- Add more options for TLS ([#193], [#196])
+- Dependencies update ([#195]):
+  - core:
+    - bamboo, ~> 2.2.0
+
+[#191]: https://github.com/fewlinesco/bamboo_smtp/pull/191
+[#193]: https://github.com/fewlinesco/bamboo_smtp/pull/193
+[#195]: https://github.com/fewlinesco/bamboo_smtp/pull/195
+[#196]: https://github.com/fewlinesco/bamboo_smtp/pull/196
 
 ## 4.0.1
 - Add support for attachment unicode file names by encoding them using format described in [RFC 2231] ([#183]).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The package can be installed as:
 
    ```elixir
    def deps do
-     [{:bamboo_smtp, "~> 4.0.1"}]
+     [{:bamboo_smtp, "~> 4.1.0"}]
    end
    ```
 
@@ -46,7 +46,7 @@ The package can be installed as:
      tls_log_level: :error,
      tls_verify: :verify_peer, # optional, can be `:verify_peer` or `:verify_none`
      tls_cacertfile: "/somewhere/on/disk", # optional, path to the ca truststore
-     tls_cacerts: "…", # optional, DER-encoded trusted certificates 
+     tls_cacerts: "…", # optional, DER-encoded trusted certificates
      tls_depth: 3, # optional, tls certificate chain depth
      tls_verify_fun: {&:ssl_verify_hostname.verify_fun/3, check_hostname: "example.com"}, # optional, tls verification function
      ssl: false, # can be `true`

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule BambooSmtp.Mixfile do
   use Mix.Project
 
   @project_url "https://github.com/fewlinesco/bamboo_smtp"
-  @version "4.0.1"
+  @version "4.1.0"
 
   def project do
     [


### PR DESCRIPTION
This release includes:

- Bump elixir to 1.12.0 and erlang to 24.0 (#191)
- Add more options for TLS (#193, #196)
- Dependencies update (#195):
  - core:
    - bamboo, ~> 2.2.0
