### PR TITLE
Remove explicit ranch dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,6 @@ defmodule BambooSmtp.Mixfile do
       # core
       {:bamboo, "~> 2.2.0"},
       {:gen_smtp, "~> 1.2.0"},
-      {:ranch, "2.0.0"},
 
       # dev / test
       {:credo, "~> 1.6.1", only: [:dev, :test]},


### PR DESCRIPTION
This fixes a version conflict on `ranch` that comes up with the latest version of `cowboy`, introduced in https://github.com/fewlinesco/bamboo_smtp/pull/205 (on my suggestion, sorry!).

We originally added this to help address issues with older Elixir / OTP
versions, but we ended up dropping support for those so. I have run CI on my own fork and this change does seem to fix the issue, I also tested pulling my fork into a project that currently uses cowboy 2.9.0 and now get no issues!