### PR TITLE
Add new tls option customize_hostname_check

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The package can be installed as:
      tls_cacerts: "…", # optional, DER-encoded trusted certificates
      tls_depth: 3, # optional, tls certificate chain depth
      tls_verify_fun: {&:ssl_verify_hostname.verify_fun/3, check_hostname: "example.com"}, # optional, tls verification function
+     tls_customize_hostname_check: [match_fun: &foo/2], # required if tls_verify is :verify_peer and peer is using a wildcard certificate
      ssl: false, # can be `true`
      retries: 1,
      no_mx_lookups: false, # can be `true`

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -519,6 +519,12 @@ defmodule Bamboo.SMTPAdapter do
     end)
   end
 
+  defp to_gen_smtp_server_config({:tls_customize_hostname_check, value}, config) do
+    Keyword.update(config, :tls_options, [{:customize_hostname_check, value}], fn c ->
+      [{:customize_hostname_check, value} | c]
+    end)
+  end
+
   defp to_gen_smtp_server_config({:port, value}, config) when is_binary(value) do
     [{:port, String.to_integer(value)} | config]
   end

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -292,6 +292,7 @@ defmodule Bamboo.SMTPAdapterTest do
           tls_cacerts: "…",
           tls_depth: 99,
           tls_verify_fun: {&:ssl_verify_hostname.verify_fun/3, check_hostname: "example.com"},
+          tls_customize_hostname_check: [foo: :bar],
           allowed_tls_versions: [:tlsv1, :"tlsv1.2"]
         })
       )
@@ -306,6 +307,8 @@ defmodule Bamboo.SMTPAdapterTest do
 
     assert {&:ssl_verify_hostname.verify_fun/3, [check_hostname: "example.com"]} ==
              gen_smtp_config[:tls_options][:verify_fun]
+
+    assert [foo: :bar] == gen_smtp_config[:tls_options][:customize_hostname_check]
 
     assert [:tlsv1, :"tlsv1.2"] == gen_smtp_config[:tls_options][:versions]
   end


### PR DESCRIPTION
Adds another tls option, which is necessary when verifying the hostname on wildcard certificates (see https://github.com/erlang/otp/issues/4321).