### PR TITLE
Use tls options in sockopts for ssl connection

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -75,9 +75,20 @@ defmodule Bamboo.SMTPAdapter do
   end
 
   def deliver(email, config) do
-    gen_smtp_config =
+    tmp_gen_smtp_config =
       config
       |> to_gen_smtp_server_config
+
+    gen_smtp_config =
+      if Keyword.get(tmp_gen_smtp_config, :ssl) == true do
+        tls_options = Keyword.get(tmp_gen_smtp_config, :tls_options, [])
+
+        tmp_gen_smtp_config
+        |> Keyword.put(:sockopts, tls_options)
+        |> Keyword.delete(:tls_options)
+      else
+        tmp_gen_smtp_config
+      end
 
     response =
       try do
@@ -493,13 +504,25 @@ defmodule Bamboo.SMTPAdapter do
 
   defp to_gen_smtp_server_config({:tls_cacertfile, value}, config)
        when is_binary(value) do
+    value = String.to_charlist(value)
+
     Keyword.update(config, :tls_options, [{:cacertfile, value}], fn c ->
       [{:cacertfile, value} | c]
     end)
   end
 
+  defp to_gen_smtp_server_config({:tls_server_name_indication, name}, config)
+       when is_binary(name) do
+    name = String.to_charlist(name)
+
+    Keyword.update(config, :tls_options, [{:server_name_indication, name}], fn c ->
+      [{:server_name_indication, name} | c]
+    end)
+  end
+
   defp to_gen_smtp_server_config({:tls_cacerts, value}, config)
        when is_binary(value) do
+    value = String.to_charlist(value)
     Keyword.update(config, :tls_options, [{:cacerts, value}], fn c -> [{:cacerts, value} | c] end)
   end
 


### PR DESCRIPTION
While trying to make bamboo_smtp work with the smtp server of domainfactory (df.eu), I found I needed some options handled differently. While I'm not into the topic taming the ssl beast, I wanted to share it and maybe collect some feedback if this is wrong on my end or should fully/partly merged into bamboo_smtp.

Using it with (username/password/hostname omitted):
```
adapter: Bamboo.SMTPAdapter,
server: "sslout.df.eu",
port: 465,
tls: :if_available,
retries: 3,
auth: :always,
ssl: true,
tls_verify: :verify_peer,
tls_server_name_indication: "sslout.df.eu",
tls_depth: 10,
tls_log_level: :debug,
tls_cacertfile: CAStore.file_path()
```

It seems to me that `gen_smtp` (`v1.2`) gave up on collecting/validating the tls options (https://github.com/gen-smtp/gen_smtp/commit/3cfd421be0b6d317efe286f80e9ea9ea636a88f4) and is simply passing `sockopts` to `ssl:connect()` while using `tls_options` when using `STARTTLS`. If I read this right it might be easier to do the same, skip the validation of known tls-related config keys/values, move the configuration to `tls: [ verify: :verify_peer, … ]` and pass this to `gen_smtp`. But this would be a breaking change…

Any opinions?