### PR TITLE
Allow overriding the SMTP envelope from

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -394,7 +394,11 @@ defmodule Bamboo.SMTPAdapter do
     |> format_email_as_string
   end
 
-  defp from_without_format(%Bamboo.Email{from: from}) do
+  defp envelope_from(%Bamboo.Email{private: %{envelope_from: from}}) do
+    from
+  end
+
+  defp envelope_from(%Bamboo.Email{from: from}) do
     from
     |> format_email(:from, false)
   end
@@ -433,7 +437,7 @@ defmodule Bamboo.SMTPAdapter do
   end
 
   defp to_gen_smtp_message(email = %Bamboo.Email{}) do
-    {from_without_format(email), to_without_format(email), body(email)}
+    {envelope_from(email), to_without_format(email), body(email)}
   end
 
   defp to_gen_smtp_server_config(config) do

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -790,6 +790,19 @@ defmodule Bamboo.SMTPAdapterTest do
     assert String.contains?(raw_email, rfc822_subject)
   end
 
+  test "override envelope from" do
+    bamboo_email =
+      new_email()
+      |> Email.put_private(:envelope_from, "foo@bar.com")
+
+    bamboo_config = configuration()
+
+    {:ok, _} = SMTPAdapter.deliver(bamboo_email, bamboo_config)
+
+    assert [{{"<foo@bar.com>", _to, _raw_email}, _gen_smtp_config}] =
+             FakeGenSMTP.fetch_sent_emails()
+  end
+
   defp format_email(emails), do: format_email(emails, true)
 
   defp format_email({name, email}, true), do: "#{rfc822_encode(name)} <#{email}>"


### PR DESCRIPTION
The SMTP `MAIL FROM` command can specify a different address than the
one on the `From:` header. This address is called the 'envelope from'
and is used by MTAs for reporting bounced emails, amongst others.

This patch allows overriding the envelope from address by putting an
email address in the `:envelope_from` key of the `private` data of the
Bamboo email struct.

reference: https://www.xeams.com/difference-envelope-header.htm