### PR TITLE
Wrap errors in SMTPError to comply with Adapter.deliver/2 spec

### DIFF
--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -104,15 +104,18 @@ defmodule Bamboo.SMTPAdapter do
   def supports_attachments?, do: true
 
   defp handle_response({:error, :no_credentials}) do
-    {:error, "Username and password were not provided for authentication."}
+    {:error,
+     SMTPError.exception(
+       {:no_credentials, "Username and password were not provided for authentication."}
+     )}
   end
 
-  defp handle_response({:error, _reason, detail}) do
-    {:error, detail}
+  defp handle_response({:error, reason, detail}) do
+    {:error, SMTPError.exception({reason, detail})}
   end
 
   defp handle_response({:error, detail}) do
-    {:error, detail}
+    {:error, SMTPError.exception({:not_specified, detail})}
   end
 
   defp handle_response(response) do

--- a/test/lib/bamboo/adapters/smtp_adapter_test.exs
+++ b/test/lib/bamboo/adapters/smtp_adapter_test.exs
@@ -3,6 +3,7 @@ defmodule Bamboo.SMTPAdapterTest do
 
   alias Bamboo.Email
   alias Bamboo.SMTPAdapter
+  alias Bamboo.SMTPAdapter.SMTPError
 
   defmodule FakeGenSMTP do
     use GenServer
@@ -344,8 +345,11 @@ defmodule Bamboo.SMTPAdapterTest do
         auth: :always
       })
 
-    assert {:error, "Username and password were not provided for authentication."} =
-             SMTPAdapter.deliver(bamboo_email, bamboo_config)
+    assert {:error,
+            %SMTPError{
+              raw:
+                {:no_credentials, "Username and password were not provided for authentication."}
+            }} = SMTPAdapter.deliver(bamboo_email, bamboo_config)
   end
 
   test "deliver is successful when username and password are required and present" do
@@ -378,7 +382,8 @@ defmodule Bamboo.SMTPAdapterTest do
     bamboo_email = new_email()
     bamboo_config = configuration(%{server: "wrong.smtp.domain"})
 
-    {:error, "wrong.smtp.domain"} = SMTPAdapter.deliver(bamboo_email, bamboo_config)
+    {:error, %SMTPError{raw: {:not_specified, "wrong.smtp.domain"}}} =
+      SMTPAdapter.deliver(bamboo_email, bamboo_config)
   end
 
   test "sets default auth key if not present" do
@@ -417,7 +422,8 @@ defmodule Bamboo.SMTPAdapterTest do
     bamboo_email = new_email(from: {"Wrong User", "wrong@user.com"})
     bamboo_config = configuration()
 
-    {:error, "554 Message rejected: Email address is not verified."} =
+    {:error,
+     %SMTPError{raw: {:not_specified, "554 Message rejected: Email address is not verified."}}} =
       SMTPAdapter.deliver(bamboo_email, bamboo_config)
   end
 


### PR DESCRIPTION
In #177, this adapter was updated to comply with the new spec in Bamboo v2.

However, as suggested in [this comment](https://github.com/fewlinesco/bamboo_smtp/issues/176#issuecomment-784038072), it is still necessary to wrap the errors in `SMTPError`. This is because the [`Adapter.error/0` spec](https://hexdocs.pm/bamboo/2.2.0/Bamboo.Adapter.html#t:error/0) requires that the `error` must be a `Exception.t() | String.t()`.

Currently, `bamboo_smtp` is returning the [underlying error tuple from `gen_smtp`](https://hexdocs.pm/gen_smtp/1.2.0/gen_smtp_client.html#t:smtp_session_error/0), which is a violation of the spec and causes Elixir to complain when [Bamboo raises the exception](https://github.com/thoughtbot/bamboo/blob/v2.2.0/lib/bamboo/mailer.ex#L234). An example I have seen in server logs:

> ArgumentError: raise/1 and reraise/2 expect a module name, string or exception as the first argument, got: {:network_failure, '74.125.204.108', {:error, :closed}}

This PR wraps the errors in `SMTPError` to comply with the spec, so that it can be successfully raised by Bamboo without causing `ArgumentError`s from `raise`.