### PR TITLE
Add tls option for server_name_indication

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The package can be installed as:
      tls_cacertfile: "/somewhere/on/disk", # optional, path to the ca truststore
      tls_cacerts: "…", # optional, DER-encoded trusted certificates
      tls_depth: 3, # optional, tls certificate chain depth
+     tls_server_name_indication: ~c"smtp.domain", #Required for TLS in OTP26
      tls_verify_fun: {&:ssl_verify_hostname.verify_fun/3, check_hostname: "example.com"}, # optional, tls verification function
      ssl: false, # can be `true`
      retries: 1,

--- a/lib/bamboo/adapters/smtp_adapter.ex
+++ b/lib/bamboo/adapters/smtp_adapter.ex
@@ -492,6 +492,17 @@ defmodule Bamboo.SMTPAdapter do
     end)
   end
 
+  defp to_gen_smtp_server_config({:tls_server_name_indication, value}, config)
+       when is_binary(value) do
+    to_gen_smtp_server_config({:tls_server_name_indication, to_charlist(value)}, config)
+  end
+
+  defp to_gen_smtp_server_config({:tls_server_name_indication, value}, config) do
+    Keyword.update(config, :tls_options, [{:server_name_indication, value}], fn c ->
+      [{:server_name_indication, value} | c]
+    end)
+  end
+
   defp to_gen_smtp_server_config({:tls_verify, value}, config) when value in @tls_verify do
     Keyword.update(config, :tls_options, [{:verify, value}], fn c -> [{:verify, value} | c] end)
   end


### PR DESCRIPTION
OTP 26 is much more picky about TLS handshaking. In OTP 25, I was able to send email over STARTTLS connections with only debug-level warnings, but connections fail with `{:error, {:temporary_failure, ~c"52.192.253.213", :tls_failed}}` when running OTP 26.

In principle, I think it would be a bit less fussy to accept a configuration key `tls_options` and pass those all through to GenSmtp, as is common in other libraries (Mint, Slipstream do this if I recall) but this PR matches existing conventions for this library.

I've added a couple of tests. For convenience I also automatically convert binary to charlist, since server_name_indication must be a charlist.